### PR TITLE
Modify grey character logic to handle characters in both green/yellow…

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,10 +228,22 @@
           }
         }
 
-        // Check that all grey characters are not in the word
+        // Check grey characters with special logic for characters that also appear in green/yellow
+        const greenSet = new Set(greenPositions.filter(char => char !== null));
+        const greenYellowSet = new Set([...greenSet, ...yellowSet]);
+        
         for (let ch of graySet) {
-          if (word.includes(ch)) {
-            return false;
+          if (greenYellowSet.has(ch)) {
+            // If character appears in both green/yellow and grey, check occurrence count
+            const occurrences = (word.match(new RegExp(ch, 'g')) || []).length;
+            if (occurrences > 1) {
+              return false; // Remove words with more than one occurrence
+            }
+          } else {
+            // If character only appears in grey, exclude words containing it
+            if (word.includes(ch)) {
+              return false;
+            }
           }
         }
     


### PR DESCRIPTION
… and grey

- When a character appears in both green/yellow and grey positions, green/yellow positions take precedence
- Only exclude words with multiple occurrences of such characters
- Single occurrences are allowed (respecting green/yellow constraints)
- Characters only in grey are still completely excluded as before